### PR TITLE
QC entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,15 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.2 dev - January 19,2021
+## v.1.2.1 dev - March 18, 2022
+
+### `Added` 
+- Add CheckM nf-core module
+- Add `assembly_qc` workflow; runs QC software on existing software
+
+### `Fixed`
+- Fixed MultiQC not finding QUAST report (again)
+## v1.2.0 dev - January 19,2022
 Major refactoring to align with Nextflow DSL2 syntax.
 ### `Added`
 - Add SNPsites module

--- a/assets/multiqc_config.yaml
+++ b/assets/multiqc_config.yaml
@@ -10,7 +10,7 @@ report_section_order:
 
 sp:
     quast:
-        fn: "*_report.tsv"
+        fn: "report.tsv"
         shared: true
 
 export_plots: true

--- a/conf/base.config
+++ b/conf/base.config
@@ -37,7 +37,7 @@ process {
         time   = { check_max( 8.h   * task.attempt, 'time'    ) }
     }
     withLabel:process_high {
-        cpus   = { check_max( 16    * task.attempt, 'cpus'    ) }
+        cpus   = { check_max( 14    * task.attempt, 'cpus'    ) }
         memory = { check_max( 72.GB * task.attempt, 'memory'  ) }
         time   = { check_max( 16.h  * task.attempt, 'time'    ) }
     }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,10 +4,11 @@
 
 ## Introduction
 
-The ARETE pipeline can is designed as an end-to-end workflow manager for genome assembly, annotation, and phylogenetic analysis, beginning with read data. However, in some cases a user may wish to stop the pipeline prior to annotation or use the annotation features of the work flow with pre-existing assemblies. Therefore, ARETE allows users three use cases:
+The ARETE pipeline can is designed as an end-to-end workflow manager for genome assembly, annotation, and phylogenetic analysis, beginning with read data. However, in some cases a user may wish to stop the pipeline prior to annotation or use the annotation features of the work flow with pre-existing assemblies. Therefore, ARETE allows users four use cases:
 1. Run the full pipeline end-to-end..
 2. Input a set of reads and stop after assembly.
-3. Input a set of assemblies and perform annotation and taxonomic analyses.
+3. Input a set of assemblies and perform QC.
+4. Input a set of assemblies and perform annotation and taxonomic analyses.
 
 This document will describe how to perform each workflow.
 ## Samplesheet input
@@ -45,14 +46,14 @@ TREATMENT_REP3,AEG588A6_S6_L004_R1_001.fastq.gz,
 An [example samplesheet](../assets/samplesheet.csv) has been provided with the pipeline.
 
 ### Annotation only samplesheet
-The ARETE pipeline allows users to provide pre-existing assemblies to make use of the annotation and reporting features of the workflow. Users are expected to independently quality check these assemblies prior to use.
+The ARETE pipeline allows users to provide pre-existing assemblies to make use of the annotation and reporting features of the workflow. Users may use the `assembly_qc` entry point to perform QC on the assemblies. **Note that the QC workflow does not automatically filter low quality assemblies, it simply generates QC reports!** `assembly` and `assembly_qc` workflows accept the same format of sample sheet.
 
 The sample sheet must be a 2 column, comma-seperated CSV file with header.
 
 | Column         | Description                                                                                                                 |
 |----------------|-----------------------------------------------------------------------------------------------------------------------------|
 | `sample`       | Custom sample name. This entry will be identical for multiple sequencing libraries/runs from the same sample.               |
-|`fna_file_path`      | Full path to FASTA or fna file for assembly or genome. File has to be gzipped and have the extension ".fna.gz" or ".fasta.gz".  |
+|`fna_file_path`      | Full path to fna file for assembly or genome. File must have `.fna` file extension.  |
 ## Reference Genome
 
 For full workflow or assembly, users may provide a path to a reference genome in fasta format for use in assembly evaluation.
@@ -84,15 +85,21 @@ results         # Finished results (configurable, see below)
 # Other nextflow hidden files, eg. history of pipeline runs and old logs.
 ```
 
-As written above, the pipeline also allows users to execute only assembly or only annotation. To execute assembly:
+As written above, the pipeline also allows users to execute only assembly or only annotation. To execute assembly (reference genome optional):
 ```bash
 nextflow run arete -entry assembly --input_sample_table samplesheet.csv --reference_genome ref.fasta  -profile docker
 ```
 
-To execute annotation:
+To execute QC on pre-existing assemblies (reference genome optional):
 
 ```bash
-nextflow run fmaguire/arete -entry annotation --input_sample_table samplesheet.csv -profile docker
+nextflow run arete -entry assembly_qc --input_sample_table samplesheet.csv --reference_genome ref.fasta  -profile docker
+```
+
+To execute annotation of pre-existing assemblies:
+
+```bash
+nextflow run arete -entry annotation --input_sample_table samplesheet.csv -profile docker
 ```
 
 ## Updating the pipeline

--- a/main.nf
+++ b/main.nf
@@ -51,6 +51,11 @@ workflow annotation {
     include { ANNOTATION } from './workflows/arete'
     ANNOTATION ()
 }
+
+workflow assembly_qc {
+    include { QUALITYCHECK } from './workflows/arete'
+    QUALITYCHECK()
+}
 /*
 ========================================================================================
     RUN ALL WORKFLOWS

--- a/modules.json
+++ b/modules.json
@@ -9,6 +9,9 @@
             "blast/makeblastdb": {
                 "git_sha": "3aacd46da2b221ed47aaa05c413a828538d2c2ae"
             },
+            "checkm/lineagewf": {
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
+            },
             "diamond/blastx": {
                 "git_sha": "49da8642876ae4d91128168cd0db4f1c858d7792"
             },

--- a/modules/nf-core/modules/checkm/lineagewf/functions.nf
+++ b/modules/nf-core/modules/checkm/lineagewf/functions.nf
@@ -1,0 +1,78 @@
+//
+//  Utility functions used in nf-core DSL2 module files
+//
+
+//
+// Extract name of software tool from process name using $task.process
+//
+def getSoftwareName(task_process) {
+    return task_process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()
+}
+
+//
+// Extract name of module from process name using $task.process
+//
+def getProcessName(task_process) {
+    return task_process.tokenize(':')[-1]
+}
+
+//
+// Function to initialise default values and to generate a Groovy Map of available options for nf-core modules
+//
+def initOptions(Map args) {
+    def Map options = [:]
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
+    return options
+}
+
+//
+// Tidy up and join elements of a list to return a path string
+//
+def getPathFromList(path_list) {
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    return paths.join('/')
+}
+
+//
+// Function to save/publish module results
+//
+def saveFiles(Map args) {
+    def ioptions  = initOptions(args.options)
+    def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
+
+    // Do not publish versions.yml unless running from pytest workflow
+    if (args.filename.equals('versions.yml') && !System.getenv("NF_CORE_MODULES_TEST")) {
+        return null
+    }
+    if (ioptions.publish_by_meta) {
+        def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+        for (key in key_list) {
+            if (args.meta && key instanceof String) {
+                def path = key
+                if (args.meta.containsKey(key)) {
+                    path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                }
+                path = path instanceof String ? path : ''
+                path_list.add(path)
+            }
+        }
+    }
+    if (ioptions.publish_files instanceof Map) {
+        for (ext in ioptions.publish_files) {
+            if (args.filename.endsWith(ext.key)) {
+                def ext_list = path_list.collect()
+                ext_list.add(ext.value)
+                return "${getPathFromList(ext_list)}/$args.filename"
+            }
+        }
+    } else if (ioptions.publish_files == null) {
+        return "${getPathFromList(path_list)}/$args.filename"
+    }
+}

--- a/modules/nf-core/modules/checkm/lineagewf/main.nf
+++ b/modules/nf-core/modules/checkm/lineagewf/main.nf
@@ -1,0 +1,51 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName; getProcessName } from './functions'
+
+params.options = [:]
+options        = initOptions(params.options)
+
+process CHECKM_LINEAGEWF {
+    tag "$meta.id"
+    label 'process_medium'
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+
+    conda (params.enable_conda ? "bioconda::checkm-genome=1.1.3" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/checkm-genome:1.1.3--py_1' :
+        'quay.io/biocontainers/checkm-genome:1.1.3--py_1' }"
+
+    input:
+    tuple val(meta), path(fasta)
+    val fasta_ext
+
+    output:
+    tuple val(meta), path("${prefix}")    , emit: checkm_output
+    tuple val(meta), path("${prefix}.tsv"), emit: checkm_tsv
+    path "versions.yml"                   , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
+    """
+    checkm \\
+        lineage_wf \\
+        -t $task.cpus \\
+        -f ${prefix}.tsv \\
+        --tab_table \\
+        --pplacer_threads $task.cpus \\
+        -x $fasta_ext \\
+        $args \\
+        . \\
+        $prefix
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        checkm: \$( checkm 2>&1 | grep '...:::' | sed 's/.*CheckM v//;s/ .*//' )
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/modules/checkm/lineagewf/meta.yml
+++ b/modules/nf-core/modules/checkm/lineagewf/meta.yml
@@ -1,0 +1,58 @@
+name: checkm_lineagewf
+description: CheckM provides a set of tools for assessing the quality of genomes recovered from isolates, single cells, or metagenomes.
+keywords:
+  - checkm
+  - mag
+  - metagenome
+  - quality
+  - isolates
+  - microbes
+  - single cells
+  - completeness
+  - contamination
+  - bins
+  - genome bins
+tools:
+  - checkm:
+      description: Assess the quality of microbial genomes recovered from isolates, single cells, and metagenomes.
+      homepage: https://ecogenomics.github.io/CheckM/
+      documentation: https://github.com/Ecogenomics/CheckM/wiki
+      tool_dev_url: https://github.com/Ecogenomics/CheckM
+      doi: "10.1101/gr.186072.114"
+      licence: ["GPL v3"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - fasta:
+      type: file
+      description: One or a list of multiple FASTA files of each bin, with extension defined with the fasta_ext value
+      pattern: "*.{$fasta_ext}"
+  - fasta_ext:
+      type: value
+      description: The file-type extension suffix of the input FASTA files (e.g., fasta, fna, fa, fas)
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'sample', bin:'1' ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - checkm_output:
+      type: directory
+      description: CheckM output directory
+      pattern: "*/"
+  - checkm_tsv:
+      type: file
+      description: CheckM summary completeness statistics table
+      pattern: "*.tsv"
+
+authors:
+  - "@jfy133"

--- a/modules/nf-core/modules/kraken2/kraken2/main.nf
+++ b/modules/nf-core/modules/kraken2/kraken2/main.nf
@@ -40,7 +40,6 @@ process KRAKEN2_KRAKEN2 {
         --unclassified-out $unclassified \\
         --classified-out $classified \\
         --report ${prefix}.kraken2.report.txt \\
-        --gzip-compressed \\
         $paired \\
         $options.args \\
         $reads

--- a/modules/nf-core/modules/multiqc/main.nf
+++ b/modules/nf-core/modules/multiqc/main.nf
@@ -10,11 +10,11 @@ process MULTIQC {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
-    conda (params.enable_conda ? "bioconda::multiqc=1.10.1" : null)
+    conda (params.enable_conda ? "bioconda::multiqc=1.11" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/multiqc:1.10.1--py_0"
+        container "https://depot.galaxyproject.org/singularity/multiqc:1.11--pyhdfd78af_0"
     } else {
-        container "quay.io/biocontainers/multiqc:1.10.1--py_0"
+        container "quay.io/biocontainers/multiqc:1.11--pyhdfd78af_0"
     }
 
     input:

--- a/nextflow.config
+++ b/nextflow.config
@@ -49,7 +49,7 @@ params {
     // Defaults only, expecting to be overwritten
     max_memory                 = '125.GB'
     max_cpus                   = 16
-    max_time                   = '240.h'
+    max_time                   = '440.h'
 
 }
 

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -62,6 +62,7 @@ workflow ANNOTATION_INPUT_CHECK{
 def get_sample_info_assemblies(LinkedHashMap row) {
     def meta = [:]
     meta.id           = row.sample
+    meta.single_end = true //Bit of a hack; call assemblies "single end" to allow passing to kraken
 
     def array = []
     if (!file(row.path).exists()) {


### PR DESCRIPTION
Adds QC workflow entry.

Adds the CheckM module and allows users to perform QC on existing assemblies by running with `-entry assembly_qc`. Usage details in `usage.md`. 

Also fixes MultiQC not finding QUAST again, as the DSL2 migration broke MultiQC config yaml. 

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [X] `README.md` is updated (including new tool citations and authors/contributors).
